### PR TITLE
Remove Evaluator Interface

### DIFF
--- a/aggregated-dependency-score.go
+++ b/aggregated-dependency-score.go
@@ -15,10 +15,6 @@ type Package struct {
 	Version   string
 }
 
-type EvaluatorInterface interface {
-	EvaluateScore(ctx context.Context, p Package) (float64, error)
-}
-
 func (e *Evaluator) EvaluateScore(ctx context.Context, p Package) (float64, error) {
 	aggregatedTrustworthiness, err := e.trustworthiness.evaluate(ctx, p)
 	if err != nil {
@@ -50,9 +46,6 @@ type Evaluator struct {
 	trustworthiness trustwhorthinessEvaluator
 	converter       ScoreTrustworthinessConverter
 }
-
-// compile-time interface check
-var _ EvaluatorInterface = &Evaluator{}
 
 type trustwhorthinessEvaluator struct {
 	intrinsic IntrinsicTrustworthinessEvaluator


### PR DESCRIPTION
reverts a5392fd

keeping our public API as small as possible

the interface was not necessary as users who need it can simply declare it themselves