### PR TITLE
Detect and Ignore Dependency Cycles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode
+
 # Python stuff
 *.pyc
 *.pyo

--- a/aggregated-dependency-score.go
+++ b/aggregated-dependency-score.go
@@ -60,15 +60,15 @@ type DependencyResolver interface {
 	GetDirectDependencies(ctx context.Context, p Package) ([]Package, error)
 }
 
-func (eval *trustwhorthinessEvaluator) evaluate(ctx context.Context, p Package, ancestors map[string]struct{}) (float64, error) {
-	intrinsic, err := eval.intrinsic.EvaluateIntrinsicTrustworthiness(ctx, p)
+func (evaluator *trustwhorthinessEvaluator) evaluate(ctx context.Context, p Package, ancestors map[string]struct{}) (float64, error) {
+	intrinsic, err := evaluator.intrinsic.EvaluateIntrinsicTrustworthiness(ctx, p)
 	if err != nil {
 		return 0.0, fmt.Errorf("evaluating intrinsic trustworthiness of package: %w", err)
 	}
 
 	result := intrinsic
 
-	deps, err := eval.deps.GetDirectDependencies(ctx, p)
+	deps, err := evaluator.deps.GetDirectDependencies(ctx, p)
 	if err != nil {
 		return 0.0, fmt.Errorf("getting direct dependencies of package: %w", err)
 	}
@@ -92,7 +92,7 @@ func (eval *trustwhorthinessEvaluator) evaluate(ctx context.Context, p Package, 
 		}
 		childAncestors[p.Name] = struct{}{}
 
-		tPrimeQ, err := eval.evaluate(ctx, dep, childAncestors)
+		tPrimeQ, err := evaluator.evaluate(ctx, dep, childAncestors)
 		if err != nil {
 			return 0.0, fmt.Errorf("evaluating aggregated trustworthiness of %s: %w", dep.Name, err)
 		}

--- a/aggregated-dependency-score.go
+++ b/aggregated-dependency-score.go
@@ -74,6 +74,9 @@ func (eval *trustwhorthinessEvaluator) evaluate(ctx context.Context, p Package, 
 	}
 
 	for _, dep := range deps {
+		// XXX sometimes different names can refer to the same package,
+		// for instance with gopkg.in URLs;
+		// XXX should we consider the version as well?
 		if _, ok := ancestors[dep.Name]; ok {
 			// depedency cycle
 			// TODO emit a log

--- a/aggregated-dependency-score.go
+++ b/aggregated-dependency-score.go
@@ -78,7 +78,7 @@ func (evaluator *trustwhorthinessEvaluator) evaluate(ctx context.Context, p Pack
 		// for instance with gopkg.in URLs;
 		// XXX should we consider the version as well?
 		if _, ok := ancestors[dep.Name]; ok {
-			// depedency cycle
+			// depedency cycle (see TestCycleHandling)
 			// TODO emit a log
 			continue
 		}


### PR DESCRIPTION
Solves #9 

Sadly, evaluating for `testify` still fails after this PR but for an unrelated reason. When debugging we clearly see that before it was stuck at processing `objx` and now it continues to the next dependency (`yaml`, which causes the below error)

```
$ go run ./cmd/depscore --ecosystem go --package github.com/stretchr/testify --version v1.10.0
ERROR: evaluating score: evaluating aggregated trustworthiness of gopkg.in/yaml.v3: evaluating intrinsic trustworthiness of package: no source repository found for package version
exit status 1
```