### PR TITLE
Fix Handling of gopkg.in Packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,5 @@ jobs:
         go-version: 1.23
     - name: Run go test
       run: go test -v ./...
+    - name: Test Go Demo Program
+      run : go run ./cmd/depscore --ecosystem go --package gopkg.in/yaml.v3 --version v3.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,5 +16,7 @@ jobs:
         go-version: 1.23
     - name: Run go test
       run: go test -v ./...
-    - name: Test Go Demo Program
+    - name: "Test Go Demo Program: gopkg.in package, implicit owner"
       run : go run ./cmd/depscore --ecosystem go --package gopkg.in/yaml.v3 --version v3.0.1
+    - name: "Test Go Demo Program: gopkg.in package, explicit owner"
+      run : go run ./cmd/depscore --ecosystem go --package gopkg.in/natefinch/lumberjack.v3 --version v2.1.0+incompatible

--- a/gopkg.in.go
+++ b/gopkg.in.go
@@ -1,0 +1,38 @@
+package aggregdepscore
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var gopkginRegexp = regexp.MustCompile(`^gopkg\.in\/(?<package>[a-zA-Z0-9_\-./]+)\.v[0-9]+$`)
+
+func getGopkginRepository(packageName string) (string, error) {
+	// note: a more "correct" way would be to send a request to gopkg.in
+	// and look for a "<meta name='go-import'>" tag in the response
+	// (see https://pkg.go.dev/cmd/go#hdr-Remote_import_paths)
+	// but using a regexp is simpler and saves us a network request
+
+	// we follow the logic in https://labix.org/gopkg.in
+
+	matches := gopkginRegexp.FindStringSubmatch(packageName)
+	if len(matches) == 0 {
+		return "", errors.New("not a gopkg.in package")
+	}
+
+	p := matches[gopkginRegexp.SubexpIndex("package")]
+
+	parts := strings.Split(p, "/")
+
+	if len(parts) == 2 {
+		return fmt.Sprintf("github.com/%s/%s", parts[0], parts[1]), nil
+	}
+
+	if len(parts) == 1 {
+		return fmt.Sprintf("github.com/go-%s/%s", parts[0], parts[0]), nil
+	}
+
+	return "", fmt.Errorf("unexpected number of parts in gopkg.in package name: %s", p)
+}

--- a/gopkg.in_test.go
+++ b/gopkg.in_test.go
@@ -1,0 +1,51 @@
+package aggregdepscore
+
+import "testing"
+
+func TestGetGopkginRepository(t *testing.T) {
+	for _, each := range []struct {
+		packageName string
+		expected    string
+		expectError bool
+	}{
+		{
+			packageName: "gopkg.in/yaml.v2",
+			expected:    "github.com/go-yaml/yaml",
+			expectError: false,
+		},
+		{
+			packageName: "gopkg.in/DataDog/dd-trace-go.v1",
+			expected:    "github.com/DataDog/dd-trace-go",
+			expectError: false,
+		},
+		{
+			packageName: "wrong",
+			expectError: true,
+		},
+		{
+			packageName: "gopkg.in/noVersion",
+			expectError: true,
+		},
+		{
+			packageName: "gopkg.in/one/two/three",
+			expectError: true,
+		},
+	} {
+		t.Run(each.packageName, func(t *testing.T) {
+			actual, err := getGopkginRepository(each.packageName)
+			if each.expectError {
+				if err == nil {
+					t.Errorf("Expected error, but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+			if actual != each.expected {
+				t.Errorf("Expected %q, but got %q", each.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixing this kind of error:

```
$ go run ./cmd/depscore --ecosystem go --package gopkg.in/yaml.v3 --version v3.0.1
ERROR: evaluating score: evaluating intrinsic trustworthiness of package: no source repository found for package version
exit status 1
```

Due to https://deps.dev not being able to locate the source repository of packages from https://gopkg.in: https://deps.dev/go/gopkg.in%2Fyaml.v3/v3.0.1

Here is the mechanism gopkg.in relies on: https://pkg.go.dev/cmd/go#hdr-Remote_import_paths

> If the import path is not a known code hosting site and also lacks a version control qualifier, the go tool attempts to fetch the import over https/http and looks for a <meta> tag in the document's HTML <head>.
>
> The meta tag has the form:
> 
> ```
> <meta name="go-import" content="import-prefix vcs repo-root">
> ```

But I ended up simply using a regexp based on the logic described in https://labix.org/gopkg.in

Note the test-driven approach: I first wrote a test reproducing the error and we see that it succeeds after I write the fix.