### PR TITLE
Use "crates.io" for Rust Ecosystem

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cedricvanrompay-datadog @DataDog/software-integrity-and-trust @DataDog/sdlc-security
+* @cedricvanrompay-datadog @DataDog/sdlc-security

--- a/depsdotdev.go
+++ b/depsdotdev.go
@@ -183,6 +183,8 @@ func depsdotdevEcosystem(x string) (api.System, error) {
 	case "maven":
 		return api.System_MAVEN, nil
 	case "cargo":
+		return api.System_SYSTEM_UNSPECIFIED, fmt.Errorf(`please use "crates.io" instead of "cargo"`)
+	case "crates.io":
 		return api.System_CARGO, nil
 	case "go":
 		return api.System_GO, nil
@@ -200,7 +202,7 @@ func depsdotdevEcosystemString(x api.System) (string, error) {
 	case api.System_MAVEN:
 		return "maven", nil
 	case api.System_CARGO:
-		return "cargo", nil
+		return "crates.io", nil
 	case api.System_GO:
 		return "go", nil
 	default:


### PR DESCRIPTION
instead of "cargo" used by deps.dev

"crates.io" is used by OSV.dev

I was tempted to allow both but this may lead to corner cases like when deciding whether or not two packages are the same

also remove old team name in CODEOWNERS