### PR TITLE
Handle NPM Bundled Dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,7 @@ jobs:
       uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
       with:
         go-version: 1.23
-    - name: Run go test
+    - name: Run go unit tests
       run: go test -v ./...
-    - name: "Test Go Demo Program: gopkg.in package, implicit owner"
-      run : go run ./cmd/depscore --ecosystem go --package gopkg.in/yaml.v3 --version v3.0.1
-    - name: "Test Go Demo Program: gopkg.in package, explicit owner"
-      run : go run ./cmd/depscore --ecosystem go --package gopkg.in/natefinch/lumberjack.v3 --version v2.1.0+incompatible
+    - name: Run go integration tests
+      run: go run ./cmd/integration-tests

--- a/aggregated-dependency-score.go
+++ b/aggregated-dependency-score.go
@@ -88,7 +88,7 @@ func (evaluator *trustwhorthinessEvaluator) evaluate(ctx context.Context, p Pack
 		// XXX should we consider the version as well?
 		if _, ok := ancestors[dep.Name]; ok {
 			// depedency cycle (see TestCycleHandling)
-			// TODO emit a log
+			// TODO (https://github.com/DataDog/aggregated-dependency-score/issues/19) emit a log
 			continue
 		}
 

--- a/aggregated-dependency-score.go
+++ b/aggregated-dependency-score.go
@@ -15,6 +15,15 @@ type Package struct {
 	Version   string
 }
 
+// String returns a string representation of the package;
+//
+// Warning: this may be changed in the future
+// to return a package-url (a.k.a. "purl") string
+// (see https://github.com/package-url/purl-spec)
+func (p Package) String() string {
+	return fmt.Sprintf("%#v", p)
+}
+
 func (e *Evaluator) EvaluateScore(ctx context.Context, p Package) (float64, error) {
 	aggregatedTrustworthiness, err := e.trustworthiness.evaluate(ctx, p, nil)
 	if err != nil {
@@ -94,7 +103,7 @@ func (evaluator *trustwhorthinessEvaluator) evaluate(ctx context.Context, p Pack
 
 		tPrimeQ, err := evaluator.evaluate(ctx, dep, childAncestors)
 		if err != nil {
-			return 0.0, fmt.Errorf("evaluating aggregated trustworthiness of %s: %w", dep.Name, err)
+			return 0.0, fmt.Errorf("evaluating aggregated trustworthiness of %s: %w", dep, err)
 		}
 
 		result *= math.Pow(tPrimeQ, transitiveTrustworthinessExponent)

--- a/cmd/integration-tests/integration-tests.go
+++ b/cmd/integration-tests/integration-tests.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	aggregdepscore "github.com/DataDog/aggregated-dependency-score"
+)
+
+func main() {
+	err := run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR: "+err.Error())
+		os.Exit(1)
+	}
+}
+
+func run() (err error) {
+	testData := struct {
+		RealCases []testCase `json:"real_cases"`
+	}{}
+
+	testDataBytes, err := os.ReadFile("test-data.json")
+	if err != nil {
+		return fmt.Errorf("reading test data: %w", err)
+	}
+
+	err = json.Unmarshal(testDataBytes, &testData)
+	if err != nil {
+		return fmt.Errorf("unmarshalling test data: %w", err)
+	}
+
+	depsdotdev, err := aggregdepscore.NewDepsDotDevClient()
+	if err != nil {
+		return fmt.Errorf("creating deps.dev client: %w", err)
+	}
+
+	evaluator, err := aggregdepscore.NewEvaluator(depsdotdev, depsdotdev)
+	if err != nil {
+		return fmt.Errorf("creating evaluator: %w", err)
+	}
+
+	var caseName string
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic in test case %q: %v", caseName, r)
+		}
+	}()
+
+	ctx := context.Background()
+	nbCasesRun := 0
+	for _, testCase := range testData.RealCases {
+		caseName = testCase.Name
+
+		_, err = evaluator.EvaluateScore(ctx, testCase.Package)
+		if err != nil {
+			return fmt.Errorf("running test case %q: %w", caseName, err)
+		}
+
+		nbCasesRun++
+	}
+
+	fmt.Printf("All %d test cases passed\n", nbCasesRun)
+	return nil
+}
+
+type testCase struct {
+	Name    string
+	Package aggregdepscore.Package
+}

--- a/depsdotdev.go
+++ b/depsdotdev.go
@@ -188,7 +188,7 @@ func (c *client) GetDirectDependencies(ctx context.Context, p Package) ([]Packag
 			result = append(result, bundledDependencies...)
 		}
 
-		// TODO log a warning if hasBundledDependencies is true and the ecosystem is NOT npm
+		// TODO (https://github.com/DataDog/aggregated-dependency-score/issues/19) log a warning if hasBundledDependencies is true and the ecosystem is NOT npm
 	}
 
 	return result, nil
@@ -218,7 +218,7 @@ func (c *client) getNPMBundledDependencies(ctx context.Context, versionKey *api.
 
 	for _, dep := range requirements.Npm.Bundled {
 		if dep == nil {
-			// TODO log a warning
+			// TODO (https://github.com/DataDog/aggregated-dependency-score/issues/19) log a warning
 			continue
 		}
 
@@ -231,7 +231,7 @@ func (c *client) getNPMBundledDependencies(ctx context.Context, versionKey *api.
 		// so we use it instead.
 
 		if !strings.HasPrefix(dep.Path, "node_modules/") {
-			// TODO log a warning
+			// TODO (https://github.com/DataDog/aggregated-dependency-score/issues/19) log a warning
 			continue
 		}
 

--- a/depsdotdev.go
+++ b/depsdotdev.go
@@ -179,6 +179,7 @@ func (c *client) GetDirectDependencies(ctx context.Context, p Package) ([]Packag
 	}
 
 	if hasBundledDependencies {
+		// TODO use string constants for the ecosystem names
 		if p.Ecosystem == "npm" {
 			bundledDependencies, err := c.getNPMBundledDependencies(ctx, versionKey)
 			if err != nil {

--- a/test-data.json
+++ b/test-data.json
@@ -1,0 +1,28 @@
+{
+    "real_cases": [
+        {
+            "name": "gopkg.in package, implicit owner",
+            "package": {
+                "ecosystem": "go",
+                "name": "gopkg.in/yaml.v3",
+                "version": "v3.0.1"
+            }
+        },
+        {
+            "name": "gopkg.in package, explicit owner",
+            "package": {
+                "ecosystem": "go",
+                "name": "gopkg.in/natefinch/lumberjack.v3",
+                "version": "v2.1.0+incompatible"
+            }
+        },
+        {
+            "name": "NPM package with bundled dependencies",
+            "package": {
+                "ecosystem": "npm",
+                "name": "cdk8s",
+                "version": "2.69.33"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #13 

I used a test-driven methodology: first a failing test triggering the bug we want to fix, then the fix.

I also started using a data file and a program for integration tests instead of a series of invocations in the GitHub workflow. This will scale better and can be reused for other implementations like the Python one.